### PR TITLE
update websocket import to new repo

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 func debugSocket(ws *websocket.Conn) {

--- a/godev.go
+++ b/godev.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"code.google.com/p/go.net/websocket"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -24,6 +23,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/net/websocket"
 )
 
 const (
@@ -449,25 +450,25 @@ func main() {
 	}
 
 	cfs = chainedFileSystem{data: &cfsData{fs: bundleFileSystems, dirs: bundleDirs, pluginKeys: pluginKeys, Plugins: map[string]bool{
-		"plugins/authenticationPlugin.html":        true,
-		"plugins/fileClientPlugin.html":            true,
-		"plugins/jslintPlugin.html":                true,
-		"webtools/plugins/webToolsPlugin.html":     true,
-		"javascript/plugins/javascriptPlugin.html": true,
-		"edit/content/imageViewerPlugin.html":      true,
-		"edit/content/jsonEditorPlugin.html":       true,
-		"plugins/webEditingPlugin.html":            true,
-		"plugins/helpPlugin.html":                  true,
-		"plugins/languages/c/cPlugin.html":         true,
-		"plugins/languages/docker/dockerPlugin.html":true,
-		"plugins/languages/go/goPlugin.html":       true,
-		"plugins/languages/markdown/markdownPlugin.html":true,
-		"plugins/languages/xml/xmlPlugin.html":     true,
-		"plugins/languages/yaml/yamlPlugin.html":   true,
-		"plugins/pageLinksPlugin.html":             true,
-		"plugins/preferencesPlugin.html":           true,
-		"plugins/taskPlugin.html":                  true,
-		"shell/plugins/shellPagePlugin.html":       true,
+		"plugins/authenticationPlugin.html":              true,
+		"plugins/fileClientPlugin.html":                  true,
+		"plugins/jslintPlugin.html":                      true,
+		"webtools/plugins/webToolsPlugin.html":           true,
+		"javascript/plugins/javascriptPlugin.html":       true,
+		"edit/content/imageViewerPlugin.html":            true,
+		"edit/content/jsonEditorPlugin.html":             true,
+		"plugins/webEditingPlugin.html":                  true,
+		"plugins/helpPlugin.html":                        true,
+		"plugins/languages/c/cPlugin.html":               true,
+		"plugins/languages/docker/dockerPlugin.html":     true,
+		"plugins/languages/go/goPlugin.html":             true,
+		"plugins/languages/markdown/markdownPlugin.html": true,
+		"plugins/languages/xml/xmlPlugin.html":           true,
+		"plugins/languages/yaml/yamlPlugin.html":         true,
+		"plugins/pageLinksPlugin.html":                   true,
+		"plugins/preferencesPlugin.html":                 true,
+		"plugins/taskPlugin.html":                        true,
+		"shell/plugins/shellPagePlugin.html":             true,
 
 		"godev/go-godev.html": true,
 	}}}

--- a/terminal.go
+++ b/terminal.go
@@ -7,7 +7,7 @@ package main
 import (
 	"net/http"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 type ConnectResult struct {

--- a/test.go
+++ b/test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"sync"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 type TestLog struct {


### PR DESCRIPTION
I could not use this IDE out of the box since the import path code.google.com/p/go.net/websocket was outdated.
